### PR TITLE
feat(ai): add LiteLLM gateway, llmkube (CPU-only), searxng-mcp, memini

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../components/flux-alerts
+resources:
+  - ./namespace.yaml
+  - ./litellm-operator/ks.yaml
+  - ./litellm/ks.yaml
+  - ./llmkube/ks.yaml
+  - ./searxng-mcp/ks.yaml
+  - ./memini/ks.yaml

--- a/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/helmrelease.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: litellm-operator
+  interval: 1h
+  values:
+    controller:
+      leaderElection:
+        enabled: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    webhook:
+      enabled: true
+    llmkube:
+      # Auto-registers models served by llmkube as LiteLLM models
+      autoRegister: true

--- a/kubernetes/apps/ai/litellm-operator/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/home-operations/charts/litellm-operator
+    tag: 0.0.5
+  url: oci://ghcr.io/home-operations/charts/litellm-operator

--- a/kubernetes/apps/ai/litellm-operator/ks.yaml
+++ b/kubernetes/apps/ai/litellm-operator/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: litellm-operator
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: litellm-operator
+  interval: 1h
+  path: "./kubernetes/apps/ai/litellm-operator/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name litellm-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+  # NOTE: adjust `key` (1Password item title) and `property` (field name)
+  # below to match whatever you name these items in your vault.
+  data:
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: litellm
+        property: MASTER_KEY
+    - secretKey: DEEPSEEK_API_KEY
+      remoteRef:
+        key: deepseek
+        property: API_KEY

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./litellmproxy.yaml
+  - ./models/

--- a/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
+++ b/kubernetes/apps/ai/litellm/app/litellmproxy.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/litellm.home-operations.com/litellmproxy_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMProxy
+metadata:
+  name: litellm
+spec:
+  # renovate: datasource=docker depName=ghcr.io/berriai/litellm
+  image: ghcr.io/berriai/litellm:v1.90.3
+  replicas: 1
+  generalSettings:
+    health_check_endpoint: /v1/health
+  routerSettings:
+    routing_strategy: simple-shuffle
+    redis_host: os.environ/REDIS_HOST
+    redis_port: os.environ/REDIS_PORT
+    num_retries: 3
+    timeout: 600
+  litellmSettings:
+    cache: true
+    cache_params:
+      type: redis
+      host: os.environ/REDIS_HOST
+      port: os.environ/REDIS_PORT
+    drop_params: true
+  env:
+    - name: LITELLM_LOG
+      value: INFO
+    - name: LITELLM_MODE
+      value: PRODUCTION
+    - name: REDIS_HOST
+      value: dragonfly.database.svc.cluster.local
+    - name: REDIS_PORT
+      value: "6379"
+    - name: LITELLM_MASTER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: litellm-secret
+          key: LITELLM_MASTER_KEY
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  service:
+    type: ClusterIP
+    port: 4000
+  route:
+    hostnames:
+      - "litellm.${SECRET_DOMAIN}"
+    parentRefs:
+      - name: envoy-internal
+        namespace: network

--- a/kubernetes/apps/ai/litellm/app/models/deepseek-chat.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/deepseek-chat.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: deepseek-chat
+spec:
+  modelName: deepseek/deepseek-chat
+  params:
+    model: deepseek/deepseek-chat
+    apiBase: https://api.deepseek.com/v1
+    apiKeyRef:
+      name: litellm-secret
+      key: DEEPSEEK_API_KEY
+  info:
+    maxTokens: 65536
+    supportsFunctionCalling: true

--- a/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ollama-chat.yaml
+  - ./deepseek-chat.yaml

--- a/kubernetes/apps/ai/litellm/app/models/ollama-chat.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/ollama-chat.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: ollama-chat
+spec:
+  # NOTE: swap `llama3.1` for whatever tag you actually have pulled
+  # on your Ollama host (`ollama list` to check).
+  modelName: ollama/local
+  params:
+    model: ollama/llama3.1
+    apiBase: http://ai.local.jaimenet.com:11434
+  info:
+    supportsFunctionCalling: true

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: litellm
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: litellm
+  dependsOn:
+    - name: litellm-operator
+      namespace: ai
+    - name: dragonfly
+      namespace: database
+  interval: 1h
+  path: "./kubernetes/apps/ai/litellm/app"
+  postBuild:
+    substitute:
+      APP: litellm
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llmkube
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: llmkube
+  interval: 30m
+  values:
+    namespace: ai
+    crds:
+      install: true
+      keep: true
+    controllerManager:
+      replicaCount: 1
+      leaderElection:
+        enabled: false
+      resources:
+        requests:
+          cpu: 10m
+          memory: 78Mi
+        limits:
+          memory: 90Mi
+      podSecurityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+    metrics:
+      enabled: false
+    modelCache:
+      enabled: true
+      size: 20Gi
+      storageClass: ceph-block
+      accessMode: ReadWriteOnce
+      mountPath: /models

--- a/kubernetes/apps/ai/llmkube/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/home-operations/charts-mirror/llmkube
+    tag: 0.8.27
+  url: oci://ghcr.io/home-operations/charts-mirror/llmkube

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmkube
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: llmkube
+      namespace: ai
+  interval: 1h
+  path: "./kubernetes/apps/ai/llmkube/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmkube-models
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube-models
+  # No GPU component for now (CPU-only). When you add an Nvidia GPU:
+  #   components:
+  #     - ../../components/gpu-nvidia   # new component, deviceClassName: gpu.nvidia.com
+  dependsOn:
+    - name: llmkube
+      namespace: ai
+    # Re-add once an Nvidia device-plugin Kustomization exists:
+    # - name: nvidia-device-plugin
+    #   namespace: kube-system
+  interval: 1h
+  path: "./kubernetes/apps/ai/llmkube/models"
+  postBuild:
+    substitute:
+      APP: llmkube-models
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./qwen3-embedding-0.6b.yaml
+  - ./qwen3-reranker-0.6b.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-embedding-0.6b
+spec:
+  source: hf://Qwen/Qwen3-Embedding-0.6B-GGUF
+  files:
+    - Qwen3-Embedding-0.6B-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    # CPU-only for now. To move this onto an Nvidia GPU later:
+    #  1. install the nvidia-device-plugin (or k8s-dra-driver) so a
+    #     `nvidia.com/gpu` deviceClass/resource exists in the cluster
+    #  2. add a ResourceClaimTemplate component (mirrors
+    #     kubernetes/components/gpu but with deviceClassName: gpu.nvidia.com)
+    #  3. set accelerator: nvidia, gpu.enabled: true, and re-add a
+    #     `resourceClaims` entry pointing at that template below
+    #  4. switch the InferenceService image tag from `server` to
+    #     `server-cuda` (see qwen3-embedding InferenceService below)
+    accelerator: cpu
+    gpu:
+      enabled: false
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-embedding-0.6b
+spec:
+  modelRef: qwen3-embedding-0.6b
+  runtime: llamacpp
+  # CPU build. Swap to ghcr.io/ggml-org/llama.cpp:server-cuda when an
+  # Nvidia GPU + device plugin are available (and bump `layers` to 99
+  # in the Model above to offload).
+  image: ghcr.io/ggml-org/llama.cpp:server
+  replicas: 1
+  priority: normal
+  contextSize: 32768
+  parallelSlots: 2
+  batchSize: 4096
+  uBatchSize: 4096
+  extraArgs:
+    - --alias
+    - qwen3-embedding
+    - --embeddings
+    - --pooling
+    - last
+    - --cont-batching
+    # Adjust thread counts to match your node's actual core count
+    - --threads
+    - "4"
+    - --threads-batch
+    - "8"
+    - --mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  resources:
+    cpu: "1"
+    memory: 2Gi
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  source: hf://ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF
+  files:
+    - qwen3-reranker-0.6b-q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    # CPU-only for now — see the matching comment in
+    # qwen3-embedding-0.6b.yaml for the Nvidia GPU migration path.
+    accelerator: cpu
+    gpu:
+      enabled: false
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-reranker-0.6b
+spec:
+  modelRef: qwen3-reranker-0.6b
+  runtime: llamacpp
+  # CPU build. Swap to ghcr.io/ggml-org/llama.cpp:server-cuda once an
+  # Nvidia GPU + device plugin are available.
+  image: ghcr.io/ggml-org/llama.cpp:server
+  replicas: 1
+  priority: normal
+  contextSize: 16384
+  parallelSlots: 2
+  batchSize: 2048
+  uBatchSize: 2048
+  extraArgs:
+    - --alias
+    - qwen3-reranker
+    - --rerank
+    - --pooling
+    - rank
+    - --cont-batching
+    # Adjust thread counts to match your node's actual core count
+    - --threads
+    - "4"
+    - --threads-batch
+    - "8"
+    - --mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  resources:
+    cpu: "1"
+    memory: 2Gi
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/ai/memini/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/memini/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name memini-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+  data:
+    - secretKey: MEMINI_API_KEY
+      remoteRef:
+        key: memini
+        property: API_KEY

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: memini
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: memini
+  interval: 30m
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        containers:
+          main:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_API_KEY
+              MEMINI_BACKEND: sqlite
+              MEMINI_DEFAULT_NAMESPACE: default
+              MEMINI_DEDUP_SIMILARITY: "0.80"
+              MEMINI_SHORT_TERM_CAP: "300"
+              MEMINI_DEMOTE_AFTER: 1440h
+              MEMINI_DISTILL_ON_WRITE: "true"
+              MEMINI_EMBED_BASE_URL: http://qwen3-embedding-0-6b.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_MODEL: qwen3-embedding
+              MEMINI_EMBED_DIMS: "1024"
+              MEMINI_EMBED_MAX_CONCURRENCY: "2"
+              MEMINI_RERANK: http://qwen3-reranker-0-6b.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK_MODEL: qwen3-reranker
+              MEMINI_LOG_FORMAT: json
+              MEMINI_RECALL_MIN_SEMANTIC_SCORE: "0.46"
+              MEMINI_TOMBSTONE_TTL: 720h
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+      fsck:
+        enabled: true
+        cronjob:
+          schedule: "0 5 * * *"
+        containers:
+          fsck:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_API_KEY
+    persistence:
+      data:
+        existingClaim: memini
+    route:
+      internal:
+        enabled: true
+        hostnames:
+          - "memini.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: http
+    serviceMonitor:
+      main:
+        enabled: true

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=registry.erwanleboucher.dev/eleboucher/charts/memini
+    tag: v0.5.4
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: memini
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: memini
+  components:
+    - ../../components/volsync
+  dependsOn:
+    - name: llmkube-models
+      namespace: ai
+  interval: 1h
+  path: "./kubernetes/apps/ai/memini/app"
+  postBuild:
+    substitute:
+      APP: memini
+      VOLSYNC_CLAIM: memini
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai

--- a/kubernetes/apps/ai/searxng-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/ai/searxng-mcp/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/searxng-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/searxng-mcp/app/mcpserver.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/litellm.home-operations.com/litellmmcpserver_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMMCPServer
+metadata:
+  name: searxng-mcp
+spec:
+  alias: web_search
+  # Spins up a small HTTP bridge in front of the existing SearXNG instance
+  # (kubernetes/apps/selfhosted/searxng), which already has JSON output enabled.
+  # NOTE: verify the exposed port/env vars against whichever mcp-searxng image
+  # tag you pin below (docs vary slightly between forks of this project).
+  workload:
+    image: overtlids/mcp-searxng-enhanced:latest
+    port: 8000
+    env:
+      - name: SEARXNG_ENGINE_API_BASE_URL
+        value: http://searxng.selfhosted.svc.cluster.local:8080/search
+    volumes:
+      - name: tmp
+        emptyDir: {}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp

--- a/kubernetes/apps/ai/searxng-mcp/ks.yaml
+++ b/kubernetes/apps/ai/searxng-mcp/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: searxng-mcp
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: searxng-mcp
+  dependsOn:
+    - name: litellm-operator
+      namespace: ai
+    - name: searxng
+      namespace: selfhosted
+  interval: 1h
+  path: "./kubernetes/apps/ai/searxng-mcp/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  timeout: 5m


### PR DESCRIPTION
- litellm-operator + litellm: unified OpenAI-compatible gateway fronting
  the existing Ollama host and DeepSeek's cloud API, cached via the
  existing Dragonfly instance, exposed internally at litellm.${SECRET_DOMAIN}
- llmkube: in-cluster Qwen3 embedding + reranker inference, CPU-only
  (no GPU in the cluster yet). Migration path to an Nvidia GPU is
  documented inline in llmkube/models/*.yaml and llmkube/ks.yaml.
- searxng-mcp: LiteLLMMCPServer wrapping the existing selfhosted/searxng
  instance so web search is available as a tool to any LiteLLM client
- memini: persistent short/long-term memory service backed by the
  llmkube embedding/reranker endpoints

Follow-ups needed before this is fully live (left as TODOs/notes in the
manifests):
- create 1Password items: litellm (MASTER_KEY), deepseek (API_KEY),
  memini (API_KEY)
- confirm the actual Ollama model tag in litellm/app/models/ollama-chat.yaml
- verify the mcp-searxng-enhanced image port/env against its current docs
- add Home Assistant's Model Context Protocol integration pointed at
  https://litellm.${SECRET_DOMAIN}/mcp once litellm is up
- when an Nvidia GPU is added: install the device plugin, add a
  ResourceClaimTemplate component, flip accelerator/gpu.enabled in the
  llmkube Model specs, and switch InferenceService images to
  server-cuda (all marked inline)
